### PR TITLE
Sente 1.9.0 and transit-cljs 0.8.239

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject matthiasn/systems-toolbox-sente "0.5.18"
+(defproject matthiasn/systems-toolbox-sente "0.5.19"
   :description "WebSocket components for systems-toolbox"
   :url "https://github.com/matthiasn/systems-toolbox"
   :license {:name "Eclipse Public License"
@@ -6,15 +6,13 @@
 
   :source-paths ["src/cljc" "src/clj" "src/cljs"]
 
-  :dependencies [[org.clojure/tools.reader "1.0.0-beta1"]
-                 [org.ow2.asm/asm-all "5.1"]
-                 [org.clojure/core.async "0.2.374" :exclusions [org.clojure/tools.reader]]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [io.aviso/pretty "0.1.26"]
-                 [com.taoensso/sente "1.8.1"]
-                 [org.clojure/core.match "0.3.0-alpha4"]
+  :dependencies [[org.clojure/tools.logging "0.3.1"]
+                 [com.taoensso/sente "1.9.0" :exclusions [org.clojure/tools.reader]]
+                 [org.clojure/core.match "0.3.0-alpha4" :exclusions [org.clojure/core.memoize
+                                                                     org.clojure/tools.analyzer.jvm]]
+
                  [com.cognitect/transit-clj "0.8.285"]
-                 [com.cognitect/transit-cljs "0.8.237"]
+                 [com.cognitect/transit-cljs "0.8.239"]
                  [compojure "1.5.0"]
                  [ring "1.4.0"]
                  [ring/ring-defaults "0.2.0"]

--- a/src/clj/matthiasn/systems_toolbox_sente/server.clj
+++ b/src/clj/matthiasn/systems_toolbox_sente/server.clj
@@ -67,7 +67,7 @@
     (let [undertow-cfg (merge {:host host :port port :http2? http2?} undertow-cfg)
           user-routes (when routes-fn (routes-fn {:put-fn put-fn}))
           opts (merge {:user-id-fn user-id-fn
-                       :packer (sente-transit/get-flexi-packer :json)}
+                       :packer (sente-transit/get-transit-packer)}
                       sente-opts)
           ws (sente/make-channel-socket! sente-web-server-adapter opts)
           {:keys [ch-recv ajax-get-or-ws-handshake-fn ajax-post-fn]} ws

--- a/src/cljs/matthiasn/systems_toolbox_sente/client.cljs
+++ b/src/cljs/matthiasn/systems_toolbox_sente/client.cljs
@@ -60,9 +60,7 @@
   [cfg]
   (fn
     [put-fn]
-    (let [opts (merge {:type :auto
-                       :packer (sente-transit/get-flexi-packer :edn)}
-                      (:sente-opts cfg))
+    (let [opts (merge {:packer(sente-transit/get-transit-packer)} (:sente-opts cfg))
           ws (sente/make-channel-socket! "/chsk" opts)
           cmp-state (merge ws {:request-tags (atom {})})]
       (sente/start-chsk-router! (:ch-recv ws) (make-handler put-fn cmp-state cfg))


### PR DESCRIPTION
I was mainly basing the changes on this commit: https://github.com/matthiasn/systems-toolbox-sente/commit/97226dc0f2380962fbde5a723ac47ba4fe2b5bad.

Bumped transit-cljs to avoid 'uuid? redefinition' warning. 
