### PR TITLE
Prioritize user routes over default ones (0.5.x)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject matthiasn/systems-toolbox-sente "0.5.19"
+(defproject matthiasn/systems-toolbox-sente "0.5.20"
   :description "WebSocket components for systems-toolbox"
   :url "https://github.com/matthiasn/systems-toolbox"
   :license {:name "Eclipse Public License"

--- a/src/clj/matthiasn/systems_toolbox_sente/server.clj
+++ b/src/clj/matthiasn/systems_toolbox_sente/server.clj
@@ -74,7 +74,7 @@
           cmp-routes [(GET "/" req (content-type (response (index-page-fn req)) "text/html"))
                       (GET "/chsk" req (ajax-get-or-ws-handshake-fn req))
                       (POST "/chsk" req (ajax-post-fn req))]
-          cmp-routes (into cmp-routes user-routes)
+          cmp-routes (into user-routes cmp-routes)
           cmp-routes (into cmp-routes [(route/resources "/")
                                        (route/not-found "Page not found")])
           cmp-routes (apply routes cmp-routes)]


### PR DESCRIPTION
This allows to override even default /chsk endpoints if such is a wish of a user ;)
