### PR TITLE
Fix chsk/state handler after 1.9.0 sente upgrade

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject matthiasn/systems-toolbox-sente "0.5.20"
+(defproject matthiasn/systems-toolbox-sente "0.5.21"
   :description "WebSocket components for systems-toolbox"
   :url "https://github.com/matthiasn/systems-toolbox"
   :license {:name "Eclipse Public License"

--- a/src/cljs/matthiasn/systems_toolbox_sente/client.cljs
+++ b/src/cljs/matthiasn/systems_toolbox_sente/client.cljs
@@ -44,7 +44,7 @@
   (fn [{:keys [event]}]
     (let [request-tags (:request-tags cmp-state)]
       (match event
-             [:chsk/state {:first-open? true}] (handle-first-open put-fn cmp-state)
+             [:chsk/state [_ {:first-open? true}]] (handle-first-open put-fn cmp-state)
              [:chsk/recv payload] (let [msg-w-meta (u/deserialize-meta payload)]
                                     (when (:count-open-requests cfg)
                                       (swap! request-tags dissoc (:tag (meta msg-w-meta)))


### PR DESCRIPTION
I've somehow missed that change in the protocol when bumped sente for 0.5.x!
