### PR TITLE
Allow ring-defaults' defaults to be supplied from the outside.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject matthiasn/systems-toolbox-sente "0.5.24"
+(defproject matthiasn/systems-toolbox-sente "0.5.25"
   :description "WebSocket components for systems-toolbox"
   :url "https://github.com/matthiasn/systems-toolbox"
   :license {:name "Eclipse Public License"

--- a/src/clj/matthiasn/systems_toolbox_sente/server.clj
+++ b/src/clj/matthiasn/systems_toolbox_sente/server.clj
@@ -14,7 +14,7 @@
     [taoensso.sente.server-adapters.immutant :refer (sente-web-server-adapter)]
     [taoensso.sente.packers.transit :as sente-transit]))
 
-(def ring-defaults-config
+(def default-ring-defaults-config
   (assoc-in rmd/site-defaults [:security :anti-forgery]
             {:read-token (fn [req] (-> req :params :csrf-token))}))
 
@@ -59,10 +59,12 @@
        :key-password \"some-random-password\"}
 
   In order to disable unencrypted listening altogether, the :port key with a nil value can be specified."
-  [{:keys [index-page-fn middleware user-id-fn routes-fn host port undertow-cfg sente-opts]
+  [{:keys [index-page-fn middleware user-id-fn routes-fn host port undertow-cfg sente-opts
+           ring-defaults-config]
     :or   {user-id-fn random-user-id-fn
            host default-host
-           port default-port}}]
+           port default-port
+           ring-defaults-config default-ring-defaults-config}}]
   (fn [put-fn]
     (let [undertow-cfg (merge {:host host :port port :http2? http2?} undertow-cfg)
           wrap-routes-defaults #(wrap-routes (apply routes %) rmd/wrap-defaults ring-defaults-config)


### PR DESCRIPTION
Sorry to bug you again @matthiasn :)
I've got another change that I need. It's related to #9 - once I started wrapping my API routes with custom middleware stack, by using `wrap-routes-defaults` that I introduced yesterday, I realised this means that my API routes now do not share Ring session with rest of app (most importantly - with index page, which is wrapped in a session by `systems-toolbox-sente`).

This is a blocker of course, and so the easiest fix I could think of, and one that actually brings even more flexibility into `systems-toolbox-sente`, is to let user supply their own `ring-defaults-config`.

With the change from this PR applied, I can now do something like this in our code:

```clojure
;; systems-toolbox-sente conf map
{:routes-fn ...
 :ring-defaults-config (assoc-in sente/default-ring-defaults-config
                                 [:session :store]
                                 ;; Custom atom passed to ring.middleware.session.memory/memory-store
                                 ;; will be used in sessions for both my custom routes that I wrap myself
                                 ;; either using wrap-routes-defaults from matthiasn.systems-toolbox-sente.server,
                                 ;; or fully manually using ring-session myself, and in any routes
                                 ;; created by systems-toolbox-sente.
                                 (rsm/memory-store (atom {})))
```

This will allow users to override any ring-defaults config, not only session, but by default, it wouldn't change systems-toolbox's behaviour.

Does it make sense?